### PR TITLE
Installing nexus_cli at compile time

### DIFF
--- a/recipes/cli.rb
+++ b/recipes/cli.rb
@@ -19,5 +19,5 @@
 #
 chef_gem "nexus_cli" do
   version "4.1.0"
-  compile_time false if Chef::Resource::ChefGem.method_defined?(:compile_time)
+  compile_time true if Chef::Resource::ChefGem.method_defined?(:compile_time)
 end


### PR DESCRIPTION
- The recipe cli needs to talk to nexus to get the repositories
  at compile time
